### PR TITLE
Resolution to https://github.com/rpearce/react-expanding-textarea/issues/33

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -32,7 +32,6 @@ export const resize = (rows, el) => {
     el.style.height = '0'
     el.style.overflowY = 'hidden'
     el.style.height = `${getHeight(rows, el)}px`
-    el.style.overflowY = 'auto'
   }
 }
 


### PR DESCRIPTION
Resolution for https://github.com/rpearce/react-expanding-textarea/issues/33
Deleted {el.style.overflowY = 'hidden'}
For auto-scroll to work with the focus on the text, the overflow-y should be set to `hidden`